### PR TITLE
29 optimize cpugpu data transfer

### DIFF
--- a/sagesim/agent.py
+++ b/sagesim/agent.py
@@ -265,12 +265,6 @@ class AgentFactory:
         neighborrankandagentidsvisited = set()
         num_agents_this_rank = len(agent_ids_chunk)
 
-        # # DEBUG: Print contextualization details
-        # print(f"\n[DEBUG Worker {worker}] CONTEXTUALIZE START:")
-        # print(f"  num_agents_this_rank: {num_agents_this_rank}")
-        # print(f"  agent_ids_chunk: {agent_ids_chunk}")
-        # print(f"  all_neighbors (first 3): {all_neighbors[:min(3, len(all_neighbors))]}")
-
         for agent_idx in range(num_agents_this_rank):
             agent_id = agent_ids_chunk[agent_idx]
             agent_adts = [adt[agent_idx] for adt in agent_data_tensors]
@@ -286,12 +280,6 @@ class AgentFactory:
                 if neighbor_rank != worker:
                     has_cross_worker_neighbors = True
                     break
-
-            # # DEBUG: Print per-agent details
-            # if agent_idx < 3:  # Only first 3 agents
-            #     print(f"  Agent {agent_id} (idx={agent_idx}):")
-            #     print(f"    Neighbors: {all_neighbors[agent_idx]}")
-            #     print(f"    has_cross_worker_neighbors: {has_cross_worker_neighbors}")
 
             # Optimization: Skip sending if data hasn't changed AND agent has no cross-worker neighbors
             # Agents with cross-worker neighbors must always be sent to maintain agent_id_to_index mapping
@@ -333,14 +321,10 @@ class AgentFactory:
                 if np.isnan(neighbor_id):
                     break
                 if int(neighbor_id) < 0:  # Skip invalid/external agent IDs (e.g., -1 for external inputs)
-                    # if agent_idx < 3:  # DEBUG
-                    #     print(f"    Skipping neighbor_id={neighbor_id} (< 0)")
                     continue
                 neighbor_rank = self._agent2rank[int(neighbor_id)]
                 if neighbor_rank == worker:
                     # Don't send to self
-                    # if agent_idx < 3:  # DEBUG
-                    #     print(f"    Skipping neighbor_id={neighbor_id} (same rank)")
                     continue
                 if (neighbor_rank, agent_id) not in neighborrankandagentidsvisited:
                     # Don't send the same agent to the same rank multiple times
@@ -350,8 +334,6 @@ class AgentFactory:
                     neighborrank2agentidandadt[neighbor_rank].append(
                         (agent_id, agent_adts)
                     )
-                    # if agent_idx < 3:  # DEBUG
-                    #     print(f"    Sending agent {agent_id} to rank {neighbor_rank}")
 
         received_neighbor_adts = []
         received_neighbor_ids = []
@@ -454,14 +436,6 @@ class AgentFactory:
             received_neighbor_ids.append(neighbor_id)
             for prop_idx in range(self.num_properties):
                 received_neighbor_adts[prop_idx].append(adts[prop_idx])
-
-        # # DEBUG: Print what was sent/received
-        # print(f"\n[DEBUG Worker {worker}] CONTEXTUALIZE END:")
-        # print(f"  Sending to other workers: {list(neighborrank2agentidandadt.keys())}")
-        # for rank, data in neighborrank2agentidandadt.items():
-        #     print(f"    To worker {rank}: {len(data)} agents - {[aid for aid, _ in data]}")
-        # print(f"  Received {len(received_neighbor_ids)} neighbors: {received_neighbor_ids}")
-        # print()
 
         return (
             agent_ids_chunk,

--- a/sagesim/model.py
+++ b/sagesim/model.py
@@ -395,40 +395,14 @@ class Model:
             # Convert on CPU (fast with hash map), then transfer to GPU
             locations_cpu = original_locations if not isinstance(original_locations, cp.ndarray) else original_locations.get()
 
-            # # DEBUG: Print synapse neighbor conversion details
-            # print(f"\n[DEBUG Worker {worker} Tick {self.tick}] LOCATION CONVERSION:")
-            # print(f"  Number of local agents: {len(self.__rank_local_agent_ids)}")
-            # print(f"  Local agent IDs: {self.__rank_local_agent_ids}")
-            # print(f"  Received neighbor IDs: {received_neighbor_ids[:10] if len(received_neighbor_ids) > 10 else received_neighbor_ids}")
-            # print(f"  all_agent_ids_list: {all_agent_ids_list}")
-            # print(f"  agent_id_to_index map: {agent_id_to_index}")
-            # for i, agent_id in enumerate(self.__rank_local_agent_ids[:3]):  # Show first 3 agents
-            #     print(f"  Agent {agent_id} (local_idx={i}):")
-            #     print(f"    Original neighbors (agent IDs): {locations_cpu[i]}")
-            #     if i < len(locations_cpu):
-            #         neighbors_with_mapping = []
-            #         for neighbor_id in (locations_cpu[i] if hasattr(locations_cpu[i], '__iter__') and not isinstance(locations_cpu[i], str) else [locations_cpu[i]]):
-            #             if not np.isnan(neighbor_id):
-            #                 neighbor_id_int = int(neighbor_id)
-            #                 idx = agent_id_to_index.get(neighbor_id_int, -1)
-            #                 neighbors_with_mapping.append(f"{neighbor_id_int}→{idx}")
-            #         print(f"    Neighbor ID → Index mapping: {neighbors_with_mapping}")
-
             locations_as_indices = convert_agent_ids_to_indices(
                 locations_cpu, agent_id_to_index
             )
-
-            # # DEBUG: Print converted results
-            # for i, agent_id in enumerate(self.__rank_local_agent_ids[:3]):  # Show first 3 agents
-            #     print(f"  Agent {agent_id} converted neighbors (indices): {locations_as_indices[i]}")
 
             # Convert to int32 array, replacing NaN with -1 for efficient indexing
             # This allows users to directly use indices without int() casting
             locations_np = np.array(locations_as_indices, dtype=np.float32)
             locations_np = np.where(np.isnan(locations_np), -1, locations_np)
-
-            # print(f"  Final locations_np (first 3): {locations_np[:3]}")
-            # print()
 
             # Create new array for kernel - cast to int32
             locations_for_kernel = cp.array(locations_np, dtype=cp.int32)


### PR DESCRIPTION
Fix contextualization to handle -1 as external input indicator: when using NaN in neighbor lists to indicate external inputs, the  contextualization loop would break early and skip processing subsequent neighbors. This prevented proper cross-worker data exchange in MPI mode.